### PR TITLE
Bug with the very first timer start

### DIFF
--- a/StudyHelper.UnitTests/TimerTests.cs
+++ b/StudyHelper.UnitTests/TimerTests.cs
@@ -61,6 +61,17 @@ namespace StudyHelper.WPF.Tests
             Assert.That(expectedEventFired, Is.True);
         }
 
+        [Test]
+        public void Timer_TimeInMinutes_SetTimeBeforeStart()
+        {
+            var newTime = 5;
+            _timer.TimeInMinutes = newTime;
+
+            _timer.Start();
+
+            Assert.That(_timer.TimeInMinutes, Is.EqualTo(newTime));
+        }
+
 
         /// <summary>
         /// No matter the state of the clock, whenever we change the time in TimerSettingsView it should always be set to the new value.
@@ -98,7 +109,7 @@ namespace StudyHelper.WPF.Tests
         }
 
         /// <summary>
-        ///  Checks whether Timer.TimeInMinutes is updated properly on setting new time in TimerSettingsViewModel
+        ///  Checks whether Timer.TimeInMinutes is updated properly on setting new time in TimerSettingsViewModel and starting the clock
         /// </summary>
         [Test]
         public void Timer_TimeInMinutes_OnTimerSettingsViewModelUpdate()
@@ -112,6 +123,7 @@ namespace StudyHelper.WPF.Tests
 
             _timerSettingsViewModel.SetTimeString = $"{newTime}";
             _timerSettingsViewModel.Update();
+            _pomodoroTimerViewModel.Timer.Start();
 
             Assert.That(_pomodoroTimerViewModel.Timer.TimeInMinutes, Is.EqualTo(newTime));
         }

--- a/StudyHelper.WPF/Models/Timer.cs
+++ b/StudyHelper.WPF/Models/Timer.cs
@@ -79,6 +79,8 @@ namespace StudyHelper.WPF.Models
 
         public void Start() 
         {
+            if(State is TimerState.Stopped)
+                _secondsLeft = TimeInMinutes * 60;
             _timer.Start();
             State = TimerState.Running;
         }
@@ -94,7 +96,6 @@ namespace StudyHelper.WPF.Models
             _timer.Stop();
             //Stop completely resets pomodoro
             _cycle = 1;
-            _secondsLeft = TimeInMinutes * 60;
             State = TimerState.Stopped;
         }
 


### PR DESCRIPTION
Fixed a bug where on the very first time the clock was started it didn't use the TimerSettings TimeInMinutes value, but a hard-coded value of 25.